### PR TITLE
Restrict SaleView to admin users

### DIFF
--- a/src/main/java/org/budget/App.java
+++ b/src/main/java/org/budget/App.java
@@ -37,11 +37,18 @@ public class App {
     }
 
     private static void onLogin(User user) {
-        new SaleView().open();
-       new AllSalesView().open();
-        if (user.getRole() == Role.ADMIN) {
+        Role role = user.getRole();
+
+        if (role == Role.ADMIN) {
+            new SaleView().open();
+            new AllSalesView().open();
             new AdminView().open();
             new SettingView().open();
+            return;
+        }
+
+        if (role == Role.KASIYER) {
+            new AllSalesView().open();
         }
     }
 }


### PR DESCRIPTION
## Summary
- limit SaleView to administrators during login while still launching AllSalesView for cashiers
- keep SaleView and AllSalesView available when an administrator signs in so sales can be monitored

## Testing
- `mvn -q -DskipTests package` *(fails: network unreachable while downloading Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68ca988fa8e0832bb8a322fe977c92d5