### PR TITLE
Fix expense DAO and stabilize AppState initialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,13 @@
             <version>${gson.version}</version>
         </dependency>
 
+        <!-- JetBrains annotations for null-safety hints -->
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>24.1.0</version>
+        </dependency>
+
         <!-- Excel: Apache POI (XLSX) -->
         <dependency>
             <groupId>org.apache.poi</groupId>

--- a/src/main/java/org/budget/App.java
+++ b/src/main/java/org/budget/App.java
@@ -4,6 +4,7 @@ import UI.View.LoginView;
 import UI.View.DashboardView;
 import com.formdev.flatlaf.FlatLightLaf;
 import model.User;
+import org.jetbrains.annotations.NotNull;
 import service.UserService;
 import state.AppState;
 
@@ -32,7 +33,7 @@ public class App {
         });
     }
 
-    private static void onLogin(User user) {
+    private static void onLogin(@NotNull User user) {
         User authenticated = Objects.requireNonNull(user, "user");
         DashboardView dashboard = new DashboardView(APP_STATE, authenticated);
         dashboard.open();


### PR DESCRIPTION
## Summary
- rebuild `ExpenseJdbcDAO` to remove duplicate code, guard schema differences and provide consistent CRUD handling
- streamline `AppState` business methods, annotate helper APIs and improve sale history polling logic
- add JetBrains annotation dependency and use it in `App`/`AppState` for clearer null-safety contracts

## Testing
- `mvn -q -DskipTests compile` *(fails: network unreachable while resolving Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68cbb6a93a08832baa7c1459adda5c73