### PR TITLE
Handle legacy schema differences in DAO layer

### DIFF
--- a/src/main/java/dao/jdbc/OrderJdbcDAO.java
+++ b/src/main/java/dao/jdbc/OrderJdbcDAO.java
@@ -18,11 +18,16 @@ import java.util.Set;
 
 public class OrderJdbcDAO implements OrderDAO {
 
+    private static final OrderStatus[] STATUS_VALUES = OrderStatus.values();
+
     private final DataSource dataSource;
     private final Connection externalConnection;
     private final Object statusLock = new Object();
+    private final Object statusModeLock = new Object();
     private final Set<OrderStatus> unsupportedStatuses = EnumSet.noneOf(OrderStatus.class);
     private final Set<String> unknownStatusValues = new HashSet<>();
+    private volatile boolean statusOrdinalMode;
+    private volatile boolean statusModeDetermined;
 
     public OrderJdbcDAO() {
         this(Db.getDataSource(), null);
@@ -64,7 +69,7 @@ public class OrderJdbcDAO implements OrderDAO {
     private Order map(ResultSet rs) throws SQLException {
         Long tableId = (rs.getObject("table_id") == null) ? null : rs.getLong("table_id");
         Long waiterId = (rs.getObject("waiter_id") == null) ? null : rs.getLong("waiter_id");
-        OrderStatus status = parseStatus(rs.getString("status"));
+        OrderStatus status = parseStatus(rs.getObject("status"));
 
         Order o = new Order(tableId, waiterId, status);
         o.setId(rs.getLong("id"));
@@ -93,68 +98,135 @@ public class OrderJdbcDAO implements OrderDAO {
         return o;
     }
 
-    private OrderStatus parseStatus(String value) {
+    private OrderStatus parseStatus(Object value) {
         if (value == null) {
             return OrderStatus.PENDING;
         }
+        if (value instanceof Number number) {
+            switchToOrdinalMode("Tablodan sayısal 'status' değeri okundu: " + number);
+            return fromOrdinal(number.intValue(), number.toString());
+        }
+        String text = value.toString();
+        if (text == null) {
+            return OrderStatus.PENDING;
+        }
+        String trimmed = text.trim();
+        if (trimmed.isEmpty()) {
+            return OrderStatus.PENDING;
+        }
+        if (isNumericString(trimmed)) {
+            try {
+                int ordinal = Integer.parseInt(trimmed);
+                switchToOrdinalMode("Tablodan sayısal 'status' değeri okundu: " + trimmed);
+                return fromOrdinal(ordinal, trimmed);
+            } catch (NumberFormatException ignore) {
+                // fall through
+            }
+        }
+        return parseStatusText(trimmed);
+    }
+
+    private OrderStatus parseStatusText(String value) {
         try {
             return OrderStatus.valueOf(value);
         } catch (IllegalArgumentException ex) {
-            synchronized (statusLock) {
-                if (unknownStatusValues.add(value)) {
-                    System.err.println("Bilinmeyen sipariş durumu değeri ('" + value
-                            + "'). 'PENDING' varsayıldı.");
-                }
-            }
+            recordUnknownStatus(value);
             return OrderStatus.PENDING;
         }
+    }
+
+    private OrderStatus fromOrdinal(int ordinal, String rawValue) {
+        if (ordinal >= 0 && ordinal < STATUS_VALUES.length) {
+            return STATUS_VALUES[ordinal];
+        }
+        recordUnknownStatus(rawValue);
+        return OrderStatus.PENDING;
+    }
+
+    private void recordUnknownStatus(String value) {
+        String key = value == null ? "null" : value;
+        synchronized (statusLock) {
+            if (unknownStatusValues.add(key)) {
+                System.err.println("Bilinmeyen sipariş durumu değeri ('" + key
+                        + "'). 'PENDING' varsayıldı.");
+            }
+        }
+    }
+
+    private boolean isNumericString(String value) {
+        if (value.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            if (!Character.isDigit(value.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override
     public Long create(Order e) {
-        final String sql = "INSERT INTO orders (table_id, waiter_id, note, status) VALUES (?,?,?,?)";
-        Connection connection = null;
-        try {
-            connection = acquireConnection();
-            try (PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
-                if (e.getTableId() == null) ps.setNull(1, Types.BIGINT); else ps.setLong(1, e.getTableId());
-                if (e.getWaiterId() == null) ps.setNull(2, Types.BIGINT); else ps.setLong(2, e.getWaiterId());
-                ps.setString(3, e.getNote());
-                ps.setString(4, e.getStatus().name());
+        for (int attempt = 0; attempt < 2; attempt++) {
+            Connection connection = null;
+            try {
+                connection = acquireConnection();
+                detectStatusMode(connection);
+                final String sql = "INSERT INTO orders (table_id, waiter_id, note, status) VALUES (?,?,?,?)";
+                try (PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+                    if (e.getTableId() == null) ps.setNull(1, Types.BIGINT); else ps.setLong(1, e.getTableId());
+                    if (e.getWaiterId() == null) ps.setNull(2, Types.BIGINT); else ps.setLong(2, e.getWaiterId());
+                    ps.setString(3, e.getNote());
+                    setStatusParameter(ps, 4, normalize(e.getStatus()));
 
-                ps.executeUpdate();
-                try (ResultSet rs = ps.getGeneratedKeys()) {
-                    if (rs.next()) return rs.getLong(1);
+                    ps.executeUpdate();
+                    try (ResultSet rs = ps.getGeneratedKeys()) {
+                        if (rs.next()) {
+                            return rs.getLong(1);
+                        }
+                    }
+                    throw new SQLException("No generated key for orders");
                 }
-                throw new SQLException("No generated key for orders");
+            } catch (SQLException ex) {
+                if (!statusOrdinalMode && handleStatusWriteIncompatibility(ex, connection)) {
+                    continue;
+                }
+                throw new RuntimeException(ex);
+            } finally {
+                close(connection);
             }
-        } catch (SQLException ex) {
-            throw new RuntimeException(ex);
-        } finally {
-            close(connection);
         }
+        throw new IllegalStateException("orders.status column uyumsuz");
     }
 
     @Override
     public void update(Order e) {
-        final String sql =
-                "UPDATE orders SET table_id=?, waiter_id=?, note=?, status=?, updated_at=NOW() WHERE id=?";
-        Connection connection = null;
-        try {
-            connection = acquireConnection();
-            try (PreparedStatement ps = connection.prepareStatement(sql)) {
-                if (e.getTableId() == null) ps.setNull(1, Types.BIGINT); else ps.setLong(1, e.getTableId());
-                if (e.getWaiterId() == null) ps.setNull(2, Types.BIGINT); else ps.setLong(2, e.getWaiterId());
-                ps.setString(3, e.getNote());
-                ps.setString(4, e.getStatus().name());
-                ps.setLong(5, e.getId());
-                ps.executeUpdate();
+        for (int attempt = 0; attempt < 2; attempt++) {
+            Connection connection = null;
+            try {
+                connection = acquireConnection();
+                detectStatusMode(connection);
+                final String sql =
+                        "UPDATE orders SET table_id=?, waiter_id=?, note=?, status=?, updated_at=NOW() WHERE id=?";
+                try (PreparedStatement ps = connection.prepareStatement(sql)) {
+                    if (e.getTableId() == null) ps.setNull(1, Types.BIGINT); else ps.setLong(1, e.getTableId());
+                    if (e.getWaiterId() == null) ps.setNull(2, Types.BIGINT); else ps.setLong(2, e.getWaiterId());
+                    ps.setString(3, e.getNote());
+                    setStatusParameter(ps, 4, normalize(e.getStatus()));
+                    ps.setLong(5, e.getId());
+                    ps.executeUpdate();
+                    return;
+                }
+            } catch (SQLException ex) {
+                if (!statusOrdinalMode && handleStatusWriteIncompatibility(ex, connection)) {
+                    continue;
+                }
+                throw new RuntimeException(ex);
+            } finally {
+                close(connection);
             }
-        } catch (SQLException ex) {
-            throw new RuntimeException(ex);
-        } finally {
-            close(connection);
         }
+        throw new IllegalStateException("orders.status column uyumsuz");
     }
 
     @Override
@@ -216,12 +288,13 @@ public class OrderJdbcDAO implements OrderDAO {
 
     @Override
     public List<Order> findOpenOrders() {
-        final String sql =
-                "SELECT * FROM orders WHERE status IN ('PENDING','IN_PROGRESS','READY') ORDER BY id DESC";
         List<Order> list = new ArrayList<>();
         Connection connection = null;
         try {
             connection = acquireConnection();
+            detectStatusMode(connection);
+            final String sql = "SELECT * FROM orders WHERE " + openStatusesCondition()
+                    + " ORDER BY id DESC";
             try (PreparedStatement ps = connection.prepareStatement(sql);
                  ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) list.add(map(rs));
@@ -236,11 +309,12 @@ public class OrderJdbcDAO implements OrderDAO {
 
     @Override
     public Optional<Order> findOpenOrderByTable(Long tableId) {
-        final String sql =
-                "SELECT * FROM orders WHERE table_id=? AND status IN ('PENDING','IN_PROGRESS','READY') ORDER BY id DESC LIMIT 1";
         Connection connection = null;
         try {
             connection = acquireConnection();
+            detectStatusMode(connection);
+            final String sql = "SELECT * FROM orders WHERE table_id=? AND " + openStatusesCondition()
+                    + " ORDER BY id DESC LIMIT 1";
             try (PreparedStatement ps = connection.prepareStatement(sql)) {
                 ps.setLong(1, tableId);
                 try (ResultSet rs = ps.executeQuery()) {
@@ -269,27 +343,35 @@ public class OrderJdbcDAO implements OrderDAO {
             return;
         }
 
-        final String sql = "UPDATE orders SET status=?, updated_at=NOW() WHERE id=?";
-        Connection connection = null;
-        try {
-            connection = acquireConnection();
-            try (PreparedStatement ps = connection.prepareStatement(sql)) {
-                ps.setString(1, normalized.name());
-                ps.setLong(2, orderId);
-                ps.executeUpdate();
-            }
-        } catch (SQLException ex) {
-            if (allowFallback && handleUnsupportedStatus(normalized, ex)) {
-                OrderStatus fallback = fallback(normalized);
-                if (fallback != null) {
-                    updateStatusInternal(orderId, fallback, false);
+        for (int attempt = 0; attempt < 2; attempt++) {
+            Connection connection = null;
+            try {
+                connection = acquireConnection();
+                detectStatusMode(connection);
+                final String sql = "UPDATE orders SET status=?, updated_at=NOW() WHERE id=?";
+                try (PreparedStatement ps = connection.prepareStatement(sql)) {
+                    setStatusParameter(ps, 1, normalized);
+                    ps.setLong(2, orderId);
+                    ps.executeUpdate();
                     return;
                 }
+            } catch (SQLException ex) {
+                if (!statusOrdinalMode && handleStatusWriteIncompatibility(ex, connection)) {
+                    continue;
+                }
+                if (allowFallback && handleUnsupportedStatus(normalized, ex)) {
+                    OrderStatus fallback = fallback(normalized);
+                    if (fallback != null) {
+                        updateStatusInternal(orderId, fallback, false);
+                        return;
+                    }
+                }
+                throw new RuntimeException(ex);
+            } finally {
+                close(connection);
             }
-            throw new RuntimeException(ex);
-        } finally {
-            close(connection);
         }
+        throw new RuntimeException("orders.status column uyumsuz");
     }
 
     private OrderStatus normalize(OrderStatus status) {
@@ -371,22 +453,31 @@ public class OrderJdbcDAO implements OrderDAO {
 
     @Override
     public void closeOrder(Long orderId, LocalDateTime closedAt) {
-        final String sql =
-                "UPDATE orders SET status='COMPLETED', closed_at=?, updated_at=NOW() WHERE id=?";
-        Connection connection = null;
-        try {
-            connection = acquireConnection();
-            try (PreparedStatement ps = connection.prepareStatement(sql)) {
-                ps.setTimestamp(1, Timestamp.valueOf(
-                        closedAt != null ? closedAt : LocalDateTime.now()));
-                ps.setLong(2, orderId);
-                ps.executeUpdate();
+        for (int attempt = 0; attempt < 2; attempt++) {
+            Connection connection = null;
+            try {
+                connection = acquireConnection();
+                detectStatusMode(connection);
+                final String sql =
+                        "UPDATE orders SET status=?, closed_at=?, updated_at=NOW() WHERE id=?";
+                try (PreparedStatement ps = connection.prepareStatement(sql)) {
+                    setStatusParameter(ps, 1, OrderStatus.COMPLETED);
+                    ps.setTimestamp(2, Timestamp.valueOf(
+                            closedAt != null ? closedAt : LocalDateTime.now()));
+                    ps.setLong(3, orderId);
+                    ps.executeUpdate();
+                    return;
+                }
+            } catch (SQLException ex) {
+                if (!statusOrdinalMode && handleStatusWriteIncompatibility(ex, connection)) {
+                    continue;
+                }
+                throw new RuntimeException(ex);
+            } finally {
+                close(connection);
             }
-        } catch (SQLException ex) {
-            throw new RuntimeException(ex);
-        } finally {
-            close(connection);
         }
+        throw new RuntimeException("orders.status column uyumsuz");
     }
 
     @Override
@@ -412,6 +503,231 @@ public class OrderJdbcDAO implements OrderDAO {
             throw new RuntimeException(ex);
         } finally {
             close(connection);
+        }
+    }
+
+    private void detectStatusMode(Connection connection) {
+        if (statusOrdinalMode || statusModeDetermined) {
+            return;
+        }
+        Boolean numeric = lookupStatusColumnNumeric(connection);
+        if (numeric == null) {
+            return;
+        }
+        if (numeric) {
+            switchToOrdinalMode("Veritabanı şeması sayısal 'status' sütunu bildiriyor.");
+        } else {
+            markStatusModeKnown();
+        }
+    }
+
+    private Boolean lookupStatusColumnNumeric(Connection connection) {
+        if (connection == null) {
+            return null;
+        }
+        try (PreparedStatement ps = connection.prepareStatement("SELECT status FROM orders LIMIT 1");
+             ResultSet rs = ps.executeQuery()) {
+            ResultSetMetaData meta = rs.getMetaData();
+            int type = meta.getColumnType(1);
+            if (isNumericType(type)) {
+                return true;
+            }
+            if (isStringType(type)) {
+                return false;
+            }
+            String typeName = meta.getColumnTypeName(1);
+            if (typeName != null) {
+                String lower = typeName.toLowerCase();
+                if (lower.contains("enum") || lower.contains("char") || lower.contains("text")) {
+                    return false;
+                }
+                if (lower.contains("int") || lower.contains("number")) {
+                    return true;
+                }
+            }
+        } catch (SQLException ignore) {
+            // fall back to DatabaseMetaData below
+        }
+        try {
+            DatabaseMetaData meta = connection.getMetaData();
+            String catalog = safeCatalog(connection);
+            String schema = safeSchema(connection);
+            Boolean direct = findStatusColumnNumeric(meta, catalog, schema, "orders");
+            if (direct != null) {
+                return direct;
+            }
+            return findStatusColumnNumeric(meta, catalog, schema, "ORDERS");
+        } catch (SQLException ignore) {
+            return null;
+        }
+    }
+
+    private Boolean findStatusColumnNumeric(DatabaseMetaData meta,
+                                            String catalog,
+                                            String schema,
+                                            String tablePattern) throws SQLException {
+        if (meta == null) {
+            return null;
+        }
+        try (ResultSet rs = meta.getColumns(catalog, schema, tablePattern, "status")) {
+            while (rs.next()) {
+                int dataType = rs.getInt("DATA_TYPE");
+                if (isNumericType(dataType)) {
+                    return true;
+                }
+                if (isStringType(dataType)) {
+                    return false;
+                }
+                String typeName = rs.getString("TYPE_NAME");
+                if (typeName != null) {
+                    String lower = typeName.toLowerCase();
+                    if (lower.contains("enum") || lower.contains("char") || lower.contains("text")) {
+                        return false;
+                    }
+                    if (lower.contains("int") || lower.contains("number")) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private boolean isNumericType(int type) {
+        return type == Types.TINYINT
+                || type == Types.SMALLINT
+                || type == Types.INTEGER
+                || type == Types.BIGINT
+                || type == Types.NUMERIC
+                || type == Types.DECIMAL;
+    }
+
+    private boolean isStringType(int type) {
+        return type == Types.CHAR
+                || type == Types.VARCHAR
+                || type == Types.LONGVARCHAR
+                || type == Types.NCHAR
+                || type == Types.NVARCHAR
+                || type == Types.LONGNVARCHAR
+                || type == Types.CLOB
+                || type == Types.NCLOB;
+    }
+
+    private String safeCatalog(Connection connection) {
+        try {
+            return connection.getCatalog();
+        } catch (SQLException ex) {
+            return null;
+        }
+    }
+
+    private String safeSchema(Connection connection) {
+        try {
+            return connection.getSchema();
+        } catch (SQLException | AbstractMethodError ex) {
+            return null;
+        }
+    }
+
+    private void markStatusModeKnown() {
+        synchronized (statusModeLock) {
+            statusModeDetermined = true;
+        }
+    }
+
+    private void switchToOrdinalMode(String detail) {
+        synchronized (statusModeLock) {
+            if (!statusOrdinalMode) {
+                statusOrdinalMode = true;
+                statusModeDetermined = true;
+                StringBuilder message = new StringBuilder(
+                        "Sipariş tablosundaki 'status' sütunu sayısal görünüyor. Enum adları yerine sıra numaraları kullanılacak.");
+                if (detail != null && !detail.isBlank()) {
+                    message.append(" Ayrıntı: ").append(detail);
+                }
+                System.err.println(message);
+            } else if (!statusModeDetermined) {
+                statusModeDetermined = true;
+            }
+        }
+    }
+
+    private boolean handleStatusWriteIncompatibility(SQLException ex, Connection connection) {
+        if (!isStatusConversionError(ex)) {
+            return false;
+        }
+        Boolean numeric = lookupStatusColumnNumeric(connection);
+        if (numeric != null) {
+            if (!numeric) {
+                return false;
+            }
+        } else if (!messageSuggestsNumericStatus(ex.getMessage())) {
+            return false;
+        }
+        switchToOrdinalMode(ex.getMessage());
+        return true;
+    }
+
+    private boolean isStatusConversionError(SQLException ex) {
+        SQLException current = ex;
+        while (current != null) {
+            String message = current.getMessage();
+            if (message != null) {
+                String lower = message.toLowerCase();
+                if (lower.contains("incorrect") && lower.contains("integer") && lower.contains("status")) {
+                    return true;
+                }
+                if (lower.contains("data truncated") && lower.contains("status")) {
+                    return true;
+                }
+            }
+            String state = current.getSQLState();
+            if (state != null && (state.equals("22001") || state.equals("22003") || state.equals("HY000"))) {
+                String msg = current.getMessage();
+                if (msg != null && msg.toLowerCase().contains("status")) {
+                    return true;
+                }
+            }
+            current = current.getNextException();
+        }
+        return false;
+    }
+
+    private boolean messageSuggestsNumericStatus(String message) {
+        if (message == null) {
+            return false;
+        }
+        String lower = message.toLowerCase();
+        if (!lower.contains("status")) {
+            return false;
+        }
+        if (lower.contains("integer")) {
+            return true;
+        }
+        return lower.contains("data truncated") && !lower.contains("enum");
+    }
+
+    private String openStatusesCondition() {
+        if (statusOrdinalMode) {
+            return "status IN (" + OrderStatus.PENDING.ordinal() + ","
+                    + OrderStatus.IN_PROGRESS.ordinal() + ","
+                    + OrderStatus.READY.ordinal() + ")";
+        }
+        if (!statusModeDetermined) {
+            return "(status IN ('PENDING','IN_PROGRESS','READY') OR status IN ("
+                    + OrderStatus.PENDING.ordinal() + ","
+                    + OrderStatus.IN_PROGRESS.ordinal() + ","
+                    + OrderStatus.READY.ordinal() + "))";
+        }
+        return "status IN ('PENDING','IN_PROGRESS','READY')";
+    }
+
+    private void setStatusParameter(PreparedStatement ps, int parameterIndex, OrderStatus status) throws SQLException {
+        OrderStatus effective = normalize(status);
+        if (statusOrdinalMode) {
+            ps.setInt(parameterIndex, effective.ordinal());
+        } else {
+            ps.setString(parameterIndex, effective.name());
         }
     }
 }


### PR DESCRIPTION
## Summary
- add runtime detection to ProductJdbcDAO so it falls back to the legacy `price` column when `unit_price` is unavailable
- teach OrderJdbcDAO to understand numeric status codes, reuse metadata to detect column type, and adjust all reads/writes/queries accordingly
- extend ExpenseJdbcDAO with detection for missing `user_id` and description columns and add insert/update variants that omit unsupported fields

## Testing
- `mvn -q -DskipTests package` *(fails: repository plugins unavailable because the build container has no network access)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc23e7d74832b9f5a5de0bb9fe812