### PR TITLE
Handle invalid product names and payment method aliases

### DIFF
--- a/src/main/java/model/PaymentMethod.java
+++ b/src/main/java/model/PaymentMethod.java
@@ -1,7 +1,44 @@
 package model;
 
+import java.util.Locale;
+
 public enum PaymentMethod {
-    CASH, CREDIT_CARD, DEBIT_CARD, TRANSFER, ONLINE, MIXED;
+    CASH("CASH"),
+    CREDIT_CARD("CREDIT_CARD"),
+    CARD("CREDIT_CARD"),
+    DEBIT_CARD("DEBIT_CARD"),
+    TRANSFER("TRANSFER"),
+    ONLINE("ONLINE"),
+    MIXED("MIXED");
 
+    private final String databaseValue;
 
+    PaymentMethod(String databaseValue) {
+        this.databaseValue = databaseValue;
+    }
+
+    public String getDatabaseValue() {
+        return databaseValue;
+    }
+
+    public PaymentMethod canonical() {
+        return this == CARD ? CREDIT_CARD : this;
+    }
+
+    public static PaymentMethod fromDatabaseValue(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        String normalized = trimmed.toUpperCase(Locale.ROOT);
+        for (PaymentMethod method : values()) {
+            if (method.databaseValue.equals(normalized) || method.name().equals(normalized)) {
+                return method.canonical();
+            }
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
## Summary
- add canonical database mapping helpers to `PaymentMethod`
- persist and load payment methods through the new helpers in `PaymentJdbcDAO`
- normalize invalid product names when reading from JDBC so products remain selectable
- treat column-not-found errors when fetching product prices/stocks as schema fallbacks so menus populate against legacy deployments

## Testing
- `mvn -q -DskipTests compile` *(fails: network unreachable while downloading Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0058c0a8832bbb52ce8deaadcd8f