### PR TITLE
Add product management dialogs and sales reporting enhancements

### DIFF
--- a/src/main/java/UI/AllSalesPanel.java
+++ b/src/main/java/UI/AllSalesPanel.java
@@ -1,43 +1,40 @@
 package UI;
 
+import model.ProductSalesRow;
 import state.AppState;
-import state.SaleRecord;
 
 import javax.swing.*;
 import javax.swing.table.DefaultTableModel;
 import java.awt.*;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.math.BigDecimal;
+import java.text.NumberFormat;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-
-import org.apache.poi.ss.usermodel.Row;
-import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.ss.usermodel.Workbook;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 public class AllSalesPanel extends JPanel {
     private final AppState appState;
     private final DefaultTableModel tableModel;
     private final JTable table;
     private final JSpinner dateSpinner = new JSpinner(new SpinnerDateModel(new Date(), null, null, java.util.Calendar.DAY_OF_MONTH));
-    private final JLabel totalLabel = new JLabel("0.00");
+    private final JSpinner timeSpinner = new JSpinner(new SpinnerDateModel(new Date(), null, null, java.util.Calendar.MINUTE));
+    private final JLabel summaryLabel = new JLabel(" ");
+    private final NumberFormat currencyFormat = NumberFormat.getCurrencyInstance(new Locale("tr", "TR"));
     private final PropertyChangeListener listener = this::handleStateChange;
 
     public AllSalesPanel(AppState appState) {
         this.appState = Objects.requireNonNull(appState, "appState");
         setLayout(new BorderLayout(8, 8));
 
-        tableModel = new DefaultTableModel(new Object[]{"Masa", "Bölüm", "Tutar", "Yöntem", "Kasiyer", "Zaman"}, 0) {
+        tableModel = new DefaultTableModel(new Object[]{"Ürün Adı", "Adet Toplamı", "Satır Toplamı (TL)"}, 0) {
             @Override
             public boolean isCellEditable(int row, int column) {
                 return false;
@@ -57,14 +54,14 @@ public class AllSalesPanel extends JPanel {
         panel.add(new JLabel("Tarih"));
         dateSpinner.setEditor(new JSpinner.DateEditor(dateSpinner, "yyyy-MM-dd"));
         panel.add(dateSpinner);
+        panel.add(new JLabel("Saat"));
+        timeSpinner.setEditor(new JSpinner.DateEditor(timeSpinner, "HH:mm"));
+        panel.add(timeSpinner);
         JButton listButton = new JButton("Listele");
         listButton.addActionListener(e -> refreshTable());
         panel.add(listButton);
-        JButton exportButton = new JButton("Excel'e aktar");
-        exportButton.addActionListener(e -> exportToExcel());
-        panel.add(exportButton);
-        panel.add(totalLabel);
-        totalLabel.setFont(totalLabel.getFont().deriveFont(Font.BOLD));
+        panel.add(summaryLabel);
+        summaryLabel.setFont(summaryLabel.getFont().deriveFont(Font.BOLD));
         return panel;
     }
 
@@ -75,75 +72,32 @@ public class AllSalesPanel extends JPanel {
     }
 
     private void refreshTable() {
-        LocalDate date = selectedDate();
-        List<SaleRecord> records = appState.getSalesOn(date);
+        LocalDateTime threshold = selectedDateTime();
+        List<ProductSalesRow> rows = appState.getProductSalesBefore(threshold);
         tableModel.setRowCount(0);
-        double total = 0;
-        DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
-        for (SaleRecord record : records) {
-            double amount = record.getTotal().doubleValue();
-            total += amount;
+        BigDecimal total = BigDecimal.ZERO;
+        for (ProductSalesRow row : rows) {
+            BigDecimal amount = row.getAmountTotal() == null ? BigDecimal.ZERO : row.getAmountTotal();
+            total = total.add(amount);
             tableModel.addRow(new Object[]{
-                    record.getTableNo(),
-                    record.getBuilding() + " / " + record.getSection(),
-                    String.format(Locale.getDefault(), "%.2f", amount),
-                    record.getMethod() == null ? "-" : record.getMethod().name(),
-                    record.getPerformedBy(),
-                    record.getTimestamp().format(timeFormatter)
+                    row.getProductName(),
+                    row.getQuantityTotal(),
+                    currencyFormat.format(amount)
             });
         }
-        totalLabel.setText("Toplam: " + String.format(Locale.getDefault(), "%.2f", total));
+        updateSummary(rows.size(), total);
     }
 
-    private LocalDate selectedDate() {
-        Date date = (Date) dateSpinner.getValue();
-        return Instant.ofEpochMilli(date.getTime()).atZone(ZoneId.systemDefault()).toLocalDate();
+    private LocalDateTime selectedDateTime() {
+        Date dateValue = (Date) dateSpinner.getValue();
+        LocalDate date = Instant.ofEpochMilli(dateValue.getTime()).atZone(ZoneId.systemDefault()).toLocalDate();
+        Date timeValue = (Date) timeSpinner.getValue();
+        LocalTime time = Instant.ofEpochMilli(timeValue.getTime()).atZone(ZoneId.systemDefault()).toLocalTime();
+        return LocalDateTime.of(date, time);
     }
 
-    private void exportToExcel() {
-        LocalDate date = selectedDate();
-        List<SaleRecord> records = appState.getSalesOn(date);
-
-        JFileChooser chooser = new JFileChooser();
-        chooser.setSelectedFile(new File("satislar-" + date + ".xlsx"));
-        if (chooser.showSaveDialog(this) != JFileChooser.APPROVE_OPTION) {
-            return;
-        }
-
-        File file = chooser.getSelectedFile();
-        try (Workbook workbook = new XSSFWorkbook()) {
-            Sheet sheet = workbook.createSheet("Satışlar");
-            Row header = sheet.createRow(0);
-            header.createCell(0).setCellValue("Masa");
-            header.createCell(1).setCellValue("Bölüm");
-            header.createCell(2).setCellValue("Tutar");
-            header.createCell(3).setCellValue("Yöntem");
-            header.createCell(4).setCellValue("Kasiyer");
-            header.createCell(5).setCellValue("Zaman");
-
-            DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
-            int rowIndex = 1;
-            for (SaleRecord record : records) {
-                Row row = sheet.createRow(rowIndex++);
-                row.createCell(0).setCellValue(record.getTableNo());
-                row.createCell(1).setCellValue(record.getBuilding() + " / " + record.getSection());
-                row.createCell(2).setCellValue(record.getTotal().doubleValue());
-                row.createCell(3).setCellValue(record.getMethod() == null ? "-" : record.getMethod().name());
-                row.createCell(4).setCellValue(record.getPerformedBy());
-                row.createCell(5).setCellValue(record.getTimestamp().format(timeFormatter));
-            }
-
-            for (int i = 0; i < 6; i++) {
-                sheet.autoSizeColumn(i);
-            }
-
-            try (FileOutputStream out = new FileOutputStream(file)) {
-                workbook.write(out);
-            }
-            JOptionPane.showMessageDialog(this, "Excel dosyası kaydedildi", "Bilgi", JOptionPane.INFORMATION_MESSAGE);
-        } catch (IOException ex) {
-            JOptionPane.showMessageDialog(this, "Excel kaydedilemedi: " + ex.getMessage(), "Hata", JOptionPane.ERROR_MESSAGE);
-        }
+    private void updateSummary(int rowCount, BigDecimal total) {
+        summaryLabel.setText("Satır: " + rowCount + "   Toplam: " + currencyFormat.format(total));
     }
 
     @Override

--- a/src/main/java/UI/ProductEditDialog.java
+++ b/src/main/java/UI/ProductEditDialog.java
@@ -1,0 +1,363 @@
+package UI;
+
+import model.Category;
+import model.Product;
+import model.User;
+import state.AppState;
+
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import java.awt.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+public class ProductEditDialog extends JDialog {
+
+    private final AppState appState;
+    private final User currentUser;
+    private final DefaultListModel<Product> productListModel = new DefaultListModel<>();
+    private final JList<Product> productList = new JList<>(productListModel);
+    private final JTextField searchField = new JTextField(18);
+    private final JTextField nameField = new JTextField(20);
+    private final JComboBox<CategoryItem> categoryCombo = new JComboBox<>();
+    private final JTextField priceField = new JTextField(10);
+    private final JSpinner stockSpinner = new JSpinner(new SpinnerNumberModel(0, 0, 1_000_000, 1));
+    private final JLabel messageLabel = new JLabel(" ");
+    private final PropertyChangeListener listener = this::handleEvent;
+
+    private List<Product> allProducts = List.of();
+    private Product editingProduct;
+    private Long editingProductId;
+
+    public ProductEditDialog(Window owner, AppState appState, User currentUser) {
+        super(owner, "Ürün Yönetimi", ModalityType.APPLICATION_MODAL);
+        this.appState = Objects.requireNonNull(appState, "appState");
+        this.currentUser = currentUser;
+
+        setLayout(new BorderLayout(12, 12));
+        setPreferredSize(new Dimension(780, 520));
+
+        add(buildMainPanel(), BorderLayout.CENTER);
+        add(buildFooter(), BorderLayout.SOUTH);
+
+        appState.addPropertyChangeListener(listener);
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosed(WindowEvent e) {
+                appState.removePropertyChangeListener(listener);
+            }
+        });
+
+        loadCategories();
+        loadProducts();
+        pack();
+        setLocationRelativeTo(owner);
+    }
+
+    private JComponent buildMainPanel() {
+        JPanel panel = new JPanel(new GridLayout(1, 2, 12, 12));
+        panel.setBorder(BorderFactory.createEmptyBorder(12, 12, 12, 12));
+        panel.add(buildListPanel());
+        panel.add(buildFormPanel());
+        return panel;
+    }
+
+    private JComponent buildListPanel() {
+        JPanel panel = new JPanel(new BorderLayout(8, 8));
+        JPanel searchPanel = new JPanel(new BorderLayout(4, 4));
+        searchPanel.add(new JLabel("Ara"), BorderLayout.WEST);
+        searchPanel.add(searchField, BorderLayout.CENTER);
+        panel.add(searchPanel, BorderLayout.NORTH);
+
+        productList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        productList.setCellRenderer(new ProductCellRenderer());
+        productList.addListSelectionListener(e -> {
+            if (!e.getValueIsAdjusting()) {
+                Product selected = productList.getSelectedValue();
+                showProduct(selected);
+            }
+        });
+        panel.add(new JScrollPane(productList), BorderLayout.CENTER);
+
+        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        JButton newButton = new JButton("Yeni");
+        newButton.addActionListener(e -> clearForm());
+        buttons.add(newButton);
+        panel.add(buttons, BorderLayout.SOUTH);
+
+        searchField.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                applyFilter();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                applyFilter();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                applyFilter();
+            }
+        });
+
+        return panel;
+    }
+
+    private JComponent buildFormPanel() {
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints gc = new GridBagConstraints();
+        gc.insets = new Insets(4, 4, 4, 4);
+        gc.anchor = GridBagConstraints.WEST;
+        gc.fill = GridBagConstraints.HORIZONTAL;
+        gc.weightx = 1;
+
+        int row = 0;
+        gc.gridx = 0; gc.gridy = row;
+        panel.add(new JLabel("Ad"), gc);
+        gc.gridx = 1;
+        panel.add(nameField, gc);
+
+        row++;
+        gc.gridx = 0; gc.gridy = row;
+        panel.add(new JLabel("Kategori"), gc);
+        gc.gridx = 1;
+        panel.add(categoryCombo, gc);
+
+        row++;
+        gc.gridx = 0; gc.gridy = row;
+        panel.add(new JLabel("Fiyat"), gc);
+        gc.gridx = 1;
+        panel.add(priceField, gc);
+
+        row++;
+        gc.gridx = 0; gc.gridy = row;
+        panel.add(new JLabel("Stok"), gc);
+        gc.gridx = 1;
+        panel.add(stockSpinner, gc);
+
+        row++;
+        gc.gridx = 1; gc.gridy = row; gc.anchor = GridBagConstraints.EAST;
+        JPanel formButtons = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        JButton saveButton = new JButton("Kaydet");
+        saveButton.addActionListener(e -> saveProduct());
+        formButtons.add(saveButton);
+        panel.add(formButtons, gc);
+
+        return panel;
+    }
+
+    private JComponent buildFooter() {
+        JPanel panel = new JPanel(new BorderLayout());
+        messageLabel.setBorder(BorderFactory.createEmptyBorder(4, 12, 4, 12));
+        messageLabel.setForeground(Color.DARK_GRAY);
+        panel.add(messageLabel, BorderLayout.CENTER);
+        JButton closeButton = new JButton("Kapat");
+        closeButton.addActionListener(e -> dispose());
+        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        buttons.add(closeButton);
+        panel.add(buttons, BorderLayout.EAST);
+        return panel;
+    }
+
+    private void handleEvent(PropertyChangeEvent event) {
+        if (AppState.EVENT_PRODUCTS.equals(event.getPropertyName())) {
+            SwingUtilities.invokeLater(this::loadProducts);
+        }
+    }
+
+    private void loadCategories() {
+        categoryCombo.removeAllItems();
+        categoryCombo.addItem(new CategoryItem(null, "(Kategori yok)"));
+        List<Category> categories = appState.getAllCategories();
+        for (Category category : categories) {
+            if (category != null) {
+                categoryCombo.addItem(new CategoryItem(category.getId(), category.getName()));
+            }
+        }
+    }
+
+    private void loadProducts() {
+        try {
+            allProducts = new ArrayList<>(appState.getAvailableProducts());
+        } catch (RuntimeException ex) {
+            allProducts = List.of();
+            showMessage("Ürünler yüklenemedi: " + ex.getMessage(), true);
+        }
+        applyFilter();
+    }
+
+    private void applyFilter() {
+        String query = searchField.getText() == null ? "" : searchField.getText().trim().toLowerCase(Locale.ROOT);
+        productListModel.clear();
+        for (Product product : allProducts) {
+            if (product == null) continue;
+            String name = safeName(product).toLowerCase(Locale.ROOT);
+            if (query.isEmpty() || name.contains(query)) {
+                productListModel.addElement(product);
+            }
+        }
+        if (!productListModel.isEmpty()) {
+            if (editingProductId != null) {
+                for (int i = 0; i < productListModel.size(); i++) {
+                    Product candidate = productListModel.getElementAt(i);
+                    if (Objects.equals(candidate.getId(), editingProductId)) {
+                        productList.setSelectedIndex(i);
+                        editingProduct = candidate;
+                        return;
+                    }
+                }
+            }
+            productList.setSelectedIndex(0);
+        } else {
+            clearForm();
+        }
+    }
+
+    private void showProduct(Product product) {
+        editingProduct = product;
+        editingProductId = product == null ? null : product.getId();
+        if (product == null) {
+            clearForm();
+            return;
+        }
+        nameField.setText(product.getName());
+        priceField.setText(product.getUnitPrice() == null ? "0" : product.getUnitPrice().toPlainString());
+        stockSpinner.setValue(product.getStock() == null ? 0 : product.getStock());
+        selectCategory(product.getCategoryId());
+    }
+
+    private void clearForm() {
+        editingProduct = null;
+        editingProductId = null;
+        nameField.setText("");
+        priceField.setText("0");
+        stockSpinner.setValue(0);
+        categoryCombo.setSelectedIndex(0);
+        productList.clearSelection();
+        showMessage("Yeni ürün kaydı", false);
+    }
+
+    private void selectCategory(Long categoryId) {
+        for (int i = 0; i < categoryCombo.getItemCount(); i++) {
+            CategoryItem item = categoryCombo.getItemAt(i);
+            if (Objects.equals(item.id(), categoryId)) {
+                categoryCombo.setSelectedIndex(i);
+                return;
+            }
+        }
+        categoryCombo.setSelectedIndex(0);
+    }
+
+    private void saveProduct() {
+        String name = nameField.getText() == null ? "" : nameField.getText().trim();
+        if (name.isEmpty()) {
+            showMessage("Ürün adı gerekli", true);
+            return;
+        }
+        BigDecimal price;
+        try {
+            price = parsePrice(priceField.getText());
+        } catch (NumberFormatException ex) {
+            showMessage("Fiyat değeri geçersiz", true);
+            return;
+        }
+        if (price.signum() < 0) {
+            showMessage("Fiyat negatif olamaz", true);
+            return;
+        }
+        int stock = (Integer) stockSpinner.getValue();
+        if (stock < 0) {
+            showMessage("Stok negatif olamaz", true);
+            return;
+        }
+        CategoryItem categoryItem = (CategoryItem) categoryCombo.getSelectedItem();
+        Long categoryId = categoryItem == null ? null : categoryItem.id();
+
+        try {
+            if (editingProduct == null || editingProduct.getId() == null) {
+                Product product = new Product();
+                product.setName(name);
+                product.setUnitPrice(price);
+                product.setVatRate(Product.DEFAULT_VAT);
+                product.setStock(stock);
+                product.setCategoryId(categoryId);
+                Long id = appState.createProduct(product);
+                product.setId(id);
+                editingProduct = product;
+                editingProductId = id;
+                showMessage("Ürün oluşturuldu", false);
+            } else {
+                editingProduct.setName(name);
+                editingProduct.setUnitPrice(price);
+                editingProduct.setStock(stock);
+                editingProduct.setCategoryId(categoryId);
+                appState.updateProduct(editingProduct);
+                editingProductId = editingProduct.getId();
+                showMessage("Ürün güncellendi", false);
+            }
+            loadProducts();
+        } catch (RuntimeException ex) {
+            String message = ex.getMessage();
+            if (message == null || message.isBlank()) {
+                message = "Ürün kaydedilemedi";
+            }
+            showMessage(message, true);
+        }
+    }
+
+    private BigDecimal parsePrice(String text) {
+        if (text == null) {
+            return BigDecimal.ZERO;
+        }
+        String normalized = text.replace("₺", "").replace(" ", "").replace(',', '.');
+        if (normalized.isBlank()) {
+            return BigDecimal.ZERO;
+        }
+        return new BigDecimal(normalized);
+    }
+
+    private void showMessage(String text, boolean error) {
+        messageLabel.setForeground(error ? Color.RED.darker() : new Color(0, 128, 0));
+        messageLabel.setText(text);
+    }
+
+    private String safeName(Product product) {
+        String name = product.getName();
+        if (name == null || name.isBlank()) {
+            return "Ürün";
+        }
+        return name.trim();
+    }
+
+    private static class ProductCellRenderer extends DefaultListCellRenderer {
+        @Override
+        public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+            Component c = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+            if (value instanceof Product product) {
+                String label = product.getName();
+                if (label == null || label.isBlank()) {
+                    label = "Ürün";
+                }
+                ((JLabel) c).setText(label);
+            }
+            return c;
+        }
+    }
+
+    private record CategoryItem(Long id, String name) {
+        @Override
+        public String toString() {
+            return name == null || name.isBlank() ? "(Kategori yok)" : name;
+        }
+    }
+}

--- a/src/main/java/UI/ProductPickerDialog.java
+++ b/src/main/java/UI/ProductPickerDialog.java
@@ -1,0 +1,253 @@
+package UI;
+
+import model.Product;
+import model.User;
+import state.AppState;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.math.BigDecimal;
+import java.text.NumberFormat;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+public class ProductPickerDialog extends JDialog {
+
+    private final AppState appState;
+    private final User currentUser;
+    private final int tableNo;
+    private final JPanel gridPanel = new JPanel(new GridLayout(0, 3, 12, 12));
+    private final JLabel messageLabel = new JLabel(" ");
+    private final PropertyChangeListener listener = this::handleEvent;
+    private final NumberFormat currencyFormat = NumberFormat.getCurrencyInstance(new Locale("tr", "TR"));
+    private String activeCategory;
+    private List<Product> currentProducts = List.of();
+
+    public ProductPickerDialog(Window owner, AppState appState, User currentUser, int tableNo) {
+        super(owner, "Ürün Seçici", ModalityType.APPLICATION_MODAL);
+        this.appState = Objects.requireNonNull(appState, "appState");
+        this.currentUser = currentUser;
+        this.tableNo = tableNo;
+
+        setLayout(new BorderLayout(8, 8));
+        setPreferredSize(new Dimension(720, 520));
+
+        add(buildFilters(), BorderLayout.NORTH);
+        add(buildGrid(), BorderLayout.CENTER);
+        add(buildFooter(), BorderLayout.SOUTH);
+
+        appState.addPropertyChangeListener(listener);
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosed(WindowEvent e) {
+                appState.removePropertyChangeListener(listener);
+            }
+        });
+
+        reloadProducts();
+        pack();
+        setLocationRelativeTo(owner);
+    }
+
+    private JComponent buildFilters() {
+        JPanel panel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        ButtonGroup group = new ButtonGroup();
+
+        JToggleButton allButton = new JToggleButton("Tüm Ürünler");
+        allButton.setSelected(true);
+        allButton.addActionListener(e -> {
+            activeCategory = null;
+            reloadProducts();
+        });
+
+        JToggleButton foodsButton = new JToggleButton("Yemekler");
+        foodsButton.addActionListener(e -> {
+            activeCategory = "Yemekler";
+            reloadProducts();
+        });
+
+        JToggleButton drinksButton = new JToggleButton("İçecekler");
+        drinksButton.addActionListener(e -> {
+            activeCategory = "İçecekler";
+            reloadProducts();
+        });
+
+        group.add(allButton);
+        group.add(foodsButton);
+        group.add(drinksButton);
+
+        panel.add(allButton);
+        panel.add(foodsButton);
+        panel.add(drinksButton);
+        return panel;
+    }
+
+    private JComponent buildGrid() {
+        JPanel wrapper = new JPanel(new BorderLayout());
+        gridPanel.setBorder(BorderFactory.createEmptyBorder(12, 12, 12, 12));
+        JScrollPane scrollPane = new JScrollPane(gridPanel);
+        wrapper.add(scrollPane, BorderLayout.CENTER);
+        return wrapper;
+    }
+
+    private JComponent buildFooter() {
+        JPanel panel = new JPanel(new BorderLayout());
+        messageLabel.setForeground(Color.DARK_GRAY);
+        messageLabel.setBorder(BorderFactory.createEmptyBorder(4, 8, 4, 8));
+        panel.add(messageLabel, BorderLayout.CENTER);
+        JButton closeButton = new JButton("Kapat");
+        closeButton.addActionListener(e -> dispose());
+        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        buttons.add(closeButton);
+        panel.add(buttons, BorderLayout.EAST);
+        return panel;
+    }
+
+    private void handleEvent(PropertyChangeEvent event) {
+        if (AppState.EVENT_PRODUCTS.equals(event.getPropertyName())) {
+            SwingUtilities.invokeLater(this::reloadProducts);
+        }
+    }
+
+    private void reloadProducts() {
+        List<Product> products;
+        try {
+            if (activeCategory == null || activeCategory.isBlank()) {
+                products = appState.getAvailableProducts();
+            } else {
+                products = appState.getProductsByCategoryName(activeCategory);
+            }
+        } catch (RuntimeException ex) {
+            products = List.of();
+            messageLabel.setText("Ürünler yüklenemedi: " + ex.getMessage());
+        }
+        currentProducts = products;
+        renderProducts();
+    }
+
+    private void renderProducts() {
+        gridPanel.removeAll();
+        if (currentProducts.isEmpty()) {
+            JLabel empty = new JLabel("Bu filtrede ürün bulunamadı");
+            empty.setHorizontalAlignment(SwingConstants.CENTER);
+            gridPanel.setLayout(new BorderLayout());
+            gridPanel.add(empty, BorderLayout.CENTER);
+        } else {
+            gridPanel.setLayout(new GridLayout(0, 3, 12, 12));
+            for (Product product : currentProducts) {
+                gridPanel.add(new ProductPanel(product));
+            }
+        }
+        gridPanel.revalidate();
+        gridPanel.repaint();
+    }
+
+    private void addProduct(Product product, int quantity) {
+        if (product == null || product.getId() == null) {
+            showMessage("Ürün bilgisi eksik", true);
+            return;
+        }
+        if (quantity <= 0) {
+            showMessage("Adet en az 1 olmalı", true);
+            return;
+        }
+        try {
+            appState.addItem(tableNo, product.getId(), quantity, currentUser);
+            showMessage(quantity + " x " + safeName(product) + " eklendi", false);
+        } catch (RuntimeException ex) {
+            String message = ex.getMessage();
+            if (message == null || message.isBlank()) {
+                message = "Ürün eklenemedi";
+            }
+            showMessage(message, true);
+        }
+    }
+
+    private void showMessage(String text, boolean error) {
+        messageLabel.setForeground(error ? Color.RED.darker() : new Color(0, 128, 0));
+        messageLabel.setText(text);
+    }
+
+    private String formatPrice(Product product) {
+        BigDecimal price = product.getUnitPrice();
+        if (price == null) {
+            price = BigDecimal.ZERO;
+        }
+        return currencyFormat.format(price);
+    }
+
+    private String safeName(Product product) {
+        String name = product.getName();
+        if (name == null || name.isBlank()) {
+            return "Ürün";
+        }
+        return name.trim();
+    }
+
+    private class ProductPanel extends JPanel {
+        private final Product product;
+        private final JPanel quantityPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        private final JSpinner quantitySpinner = new JSpinner(new SpinnerNumberModel(1, 1, 50, 1));
+
+        ProductPanel(Product product) {
+            super(new BorderLayout(4, 4));
+            this.product = product;
+            setBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY));
+            JButton button = new JButton(buildLabel(product));
+            button.setFocusPainted(false);
+            button.setBackground(Color.WHITE);
+            button.addActionListener(e -> toggleQuantity());
+            add(button, BorderLayout.CENTER);
+
+            JButton addButton = new JButton("Ekle");
+            addButton.addActionListener(e -> commitSelection());
+            quantityPanel.add(new JLabel("Adet"));
+            quantitySpinner.setPreferredSize(new Dimension(60, quantitySpinner.getPreferredSize().height));
+            quantityPanel.add(quantitySpinner);
+            quantityPanel.add(addButton);
+            quantityPanel.setVisible(false);
+            add(quantityPanel, BorderLayout.SOUTH);
+
+            JComponent editor = quantitySpinner.getEditor();
+            if (editor instanceof JSpinner.DefaultEditor defaultEditor) {
+                defaultEditor.getTextField().addActionListener(e -> commitSelection());
+            }
+        }
+
+        private void toggleQuantity() {
+            boolean newState = !quantityPanel.isVisible();
+            hideAllQuantityPanels();
+            quantityPanel.setVisible(newState);
+            if (newState) {
+                quantitySpinner.requestFocusInWindow();
+            }
+            revalidate();
+            repaint();
+        }
+
+        private void commitSelection() {
+            int qty = (Integer) quantitySpinner.getValue();
+            addProduct(product, qty);
+            quantitySpinner.setValue(1);
+            quantityPanel.setVisible(false);
+        }
+
+        private String buildLabel(Product product) {
+            return "<html><div style='text-align:center'><b>" + safeName(product)
+                    + "</b><br/>" + formatPrice(product) + "</div></html>";
+        }
+    }
+
+    private void hideAllQuantityPanels() {
+        for (Component component : gridPanel.getComponents()) {
+            if (component instanceof ProductPanel panel) {
+                panel.quantityPanel.setVisible(false);
+            }
+        }
+    }
+}

--- a/src/main/java/UI/View/DashboardView.java
+++ b/src/main/java/UI/View/DashboardView.java
@@ -55,7 +55,7 @@ public class DashboardView extends JFrame {
 
         List<CardConfig> configs = new ArrayList<>();
         configs.add(new CardConfig(CARD_FLOORS, "Katlar", () -> new JScrollPane(new RestaurantTablesPanel(appState, currentUser)), r -> true));
-        configs.add(new CardConfig(CARD_USERS, "Kullanıcı İşlemleri", AdminPanel::new, r -> r == Role.ADMIN));
+        configs.add(new CardConfig(CARD_USERS, "Kullanıcı İşlemleri", () -> new AdminPanel(currentUser), r -> r == Role.ADMIN));
         configs.add(new CardConfig(CARD_EXPENSES, "Giderler", () -> new ExpensesPanel(appState, currentUser), r -> r == Role.ADMIN || r == Role.KASIYER));
         configs.add(new CardConfig(CARD_SALES, "Satışlar", () -> new AllSalesPanel(appState), r -> r == Role.ADMIN || r == Role.KASIYER));
         configs.add(new CardConfig(CARD_PROFIT, "Net Kar", () -> new ProfitPanel(appState), r -> r == Role.ADMIN));

--- a/src/main/java/UI/View/RestraurantTablesView.java
+++ b/src/main/java/UI/View/RestraurantTablesView.java
@@ -1,5 +1,6 @@
 package UI.View;
 
+import UI.ProductEditDialog;
 import UI.RestaurantTablesPanel;
 import model.User;
 import state.AppState;
@@ -9,14 +10,41 @@ import java.awt.*;
 import java.util.Objects;
 
 public class RestraurantTablesView extends JFrame {
+    private final AppState appState;
+    private final User currentUser;
+
     public RestraurantTablesView(AppState appState, User user) {
         super("Restoran Masaları");
+        this.appState = Objects.requireNonNull(appState, "appState");
+        this.currentUser = Objects.requireNonNull(user, "user");
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         setLayout(new BorderLayout());
-        RestaurantTablesPanel panel = new RestaurantTablesPanel(Objects.requireNonNull(appState, "appState"), Objects.requireNonNull(user, "user"));
+        add(buildHeader(), BorderLayout.NORTH);
+        RestaurantTablesPanel panel = new RestaurantTablesPanel(this.appState, this.currentUser);
         add(new JScrollPane(panel), BorderLayout.CENTER);
         setSize(900, 600);
         setLocationRelativeTo(null);
+    }
+
+    private JComponent buildHeader() {
+        JPanel panel = new JPanel(new BorderLayout());
+        JLabel title = new JLabel("Restoran Masaları");
+        title.setFont(title.getFont().deriveFont(Font.BOLD, 16f));
+        panel.add(title, BorderLayout.WEST);
+        if (currentUser.getRole() == model.Role.ADMIN || currentUser.getRole() == model.Role.KASIYER) {
+            JButton manageButton = new JButton("Ürün ekle/güncelle");
+            manageButton.addActionListener(e -> openProductEditor());
+            JPanel buttons = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+            buttons.add(manageButton);
+            panel.add(buttons, BorderLayout.EAST);
+        }
+        panel.setBorder(BorderFactory.createEmptyBorder(8, 12, 8, 12));
+        return panel;
+    }
+
+    private void openProductEditor() {
+        ProductEditDialog dialog = new ProductEditDialog(this, appState, currentUser);
+        dialog.setVisible(true);
     }
 
     public void open() {

--- a/src/main/java/dao/ProductDAO.java
+++ b/src/main/java/dao/ProductDAO.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 public interface ProductDAO extends CrudRepository<Product, Long> {
     List<Product> searchByName(String q, int limit);
     List<Product> findByCategory(Long categoryId, int offset, int limit);
+    List<Product> findByCategoryName(String categoryName);
     void updateStock(Long productId, int delta); // +/-
     Optional<Product> findByName(String name);
 }

--- a/src/main/java/dao/ReportsDAO.java
+++ b/src/main/java/dao/ReportsDAO.java
@@ -1,0 +1,10 @@
+package dao;
+
+import model.ProductSalesRow;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ReportsDAO {
+    List<ProductSalesRow> findProductSalesBefore(LocalDateTime threshold);
+}

--- a/src/main/java/dao/UserDAO.java
+++ b/src/main/java/dao/UserDAO.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface UserDAO extends CrudRepository<User, Long> {
     Optional<User> findByUsername(String username);
     void updateRole(Long userId, Role role);
+    long countByRole(Role role);
 }

--- a/src/main/java/dao/jdbc/ProductJdbcDAO.java
+++ b/src/main/java/dao/jdbc/ProductJdbcDAO.java
@@ -351,6 +351,31 @@ public class ProductJdbcDAO implements ProductDAO {
     }
 
     @Override
+    public List<Product> findByCategoryName(String categoryName) {
+        final String sql = "SELECT p.* FROM products p " +
+                "JOIN categories c ON c.id = p.category_id " +
+                "WHERE LOWER(c.name) = LOWER(?) ORDER BY p.name";
+        List<Product> list = new ArrayList<>();
+        Connection connection = null;
+        try {
+            connection = acquireConnection();
+            try (PreparedStatement ps = connection.prepareStatement(sql)) {
+                ps.setString(1, categoryName);
+                try (ResultSet rs = ps.executeQuery()) {
+                    while (rs.next()) {
+                        list.add(map(rs));
+                    }
+                }
+            }
+        } catch (SQLException ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            close(connection);
+        }
+        return list;
+    }
+
+    @Override
     public void updateStock(Long productId, int delta) {
         if (legacyStockColumn) {
             return;

--- a/src/main/java/dao/jdbc/ReportsJdbcDAO.java
+++ b/src/main/java/dao/jdbc/ReportsJdbcDAO.java
@@ -1,0 +1,61 @@
+package dao.jdbc;
+
+import DataConnection.Db;
+import dao.ReportsDAO;
+import model.ProductSalesRow;
+
+import javax.sql.DataSource;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class ReportsJdbcDAO implements ReportsDAO {
+
+    private final DataSource dataSource;
+
+    public ReportsJdbcDAO() {
+        this(Db.getDataSource());
+    }
+
+    public ReportsJdbcDAO(DataSource dataSource) {
+        this.dataSource = Objects.requireNonNull(dataSource, "dataSource");
+    }
+
+    @Override
+    public List<ProductSalesRow> findProductSalesBefore(LocalDateTime threshold) {
+        String sql = "SELECT oi.product_name, " +
+                "SUM(oi.quantity) AS qty_total, " +
+                "SUM(COALESCE(oi.line_total, oi.quantity * oi.unit_price * 1.20)) AS amount_total " +
+                "FROM payments p " +
+                "JOIN orders o ON o.id = p.order_id " +
+                "JOIN order_items oi ON oi.order_id = o.id " +
+                "WHERE p.paid_at < ? " +
+                "GROUP BY oi.product_name " +
+                "ORDER BY amount_total DESC";
+
+        LocalDateTime safeThreshold = threshold == null ? LocalDateTime.now() : threshold;
+        List<ProductSalesRow> rows = new ArrayList<>();
+
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setObject(1, safeThreshold);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    String name = rs.getString("product_name");
+                    int qty = rs.getInt("qty_total");
+                    BigDecimal amount = rs.getBigDecimal("amount_total");
+                    rows.add(new ProductSalesRow(name, qty, amount));
+                }
+            }
+        } catch (SQLException ex) {
+            throw new RuntimeException(ex);
+        }
+        return rows;
+    }
+}

--- a/src/main/java/dao/jdbc/UserJdbcDAO.java
+++ b/src/main/java/dao/jdbc/UserJdbcDAO.java
@@ -160,4 +160,20 @@ public class UserJdbcDAO implements UserDAO {
             throw new RuntimeException(ex);
         }
     }
+
+    @Override
+    public long countByRole(Role role) {
+        final String sql = "SELECT COUNT(*) FROM users WHERE role_id = (SELECT id FROM roles WHERE name=?)";
+        try (Connection c = Db.getConnection(); PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setString(1, role.name());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getLong(1);
+                }
+            }
+            return 0L;
+        } catch (SQLException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
 }

--- a/src/main/java/model/ProductSalesRow.java
+++ b/src/main/java/model/ProductSalesRow.java
@@ -1,0 +1,54 @@
+package model;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * Basit rapor satırı taşıyıcısı.
+ */
+public class ProductSalesRow {
+    private final String productName;
+    private final int quantityTotal;
+    private final BigDecimal amountTotal;
+
+    public ProductSalesRow(String productName, int quantityTotal, BigDecimal amountTotal) {
+        this.productName = productName == null ? "" : productName.trim();
+        this.quantityTotal = Math.max(0, quantityTotal);
+        this.amountTotal = amountTotal == null ? BigDecimal.ZERO : amountTotal;
+    }
+
+    public String getProductName() {
+        return productName;
+    }
+
+    public int getQuantityTotal() {
+        return quantityTotal;
+    }
+
+    public BigDecimal getAmountTotal() {
+        return amountTotal;
+    }
+
+    @Override
+    public String toString() {
+        return "ProductSalesRow{" +
+                "productName='" + productName + '\'' +
+                ", quantityTotal=" + quantityTotal +
+                ", amountTotal=" + amountTotal +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ProductSalesRow that)) return false;
+        return quantityTotal == that.quantityTotal
+                && Objects.equals(productName, that.productName)
+                && Objects.equals(amountTotal, that.amountTotal);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(productName, quantityTotal, amountTotal);
+    }
+}

--- a/src/main/java/service/ExpenseService.java
+++ b/src/main/java/service/ExpenseService.java
@@ -43,6 +43,13 @@ public class ExpenseService {
         return expenseDAO.findAll(0, Integer.MAX_VALUE);
     }
 
+    public void deleteExpenseById(Long id) {
+        if (id == null || id <= 0) {
+            throw new IllegalArgumentException("Geçersiz gider ID");
+        }
+        expenseDAO.deleteById(id);
+    }
+
     public BigDecimal sumExpensesOn(LocalDate date) {
         return sum(expenseDAO.findByDate(date));
     }

--- a/src/main/java/service/ProductService.java
+++ b/src/main/java/service/ProductService.java
@@ -23,6 +23,13 @@ public class ProductService {
         return productDAO.findAll(0, Integer.MAX_VALUE);
     }
 
+    public List<Product> getProductsByCategoryName(String categoryName) {
+        if (categoryName == null || categoryName.isBlank()) {
+            return getAllProducts();
+        }
+        return productDAO.findByCategoryName(categoryName.trim());
+    }
+
     public Product getProductById(Long productId) {
         return productDAO.findById(productId).orElse(null);
     }

--- a/src/main/java/service/ReportsService.java
+++ b/src/main/java/service/ReportsService.java
@@ -1,0 +1,26 @@
+package service;
+
+import dao.ReportsDAO;
+import dao.jdbc.ReportsJdbcDAO;
+import model.ProductSalesRow;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+
+public class ReportsService {
+
+    private final ReportsDAO reportsDAO;
+
+    public ReportsService() {
+        this(new ReportsJdbcDAO());
+    }
+
+    public ReportsService(ReportsDAO reportsDAO) {
+        this.reportsDAO = Objects.requireNonNull(reportsDAO, "reportsDAO");
+    }
+
+    public List<ProductSalesRow> getProductSalesBefore(LocalDateTime threshold) {
+        return reportsDAO.findProductSalesBefore(threshold);
+    }
+}

--- a/src/main/java/state/ExpenseRecord.java
+++ b/src/main/java/state/ExpenseRecord.java
@@ -6,18 +6,24 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public class ExpenseRecord {
+    private final Long id;
     private final BigDecimal amount;
     private final String description;
     private final String performedBy;
     private final LocalDate expenseDate;
     private final LocalDateTime createdAt;
 
-    public ExpenseRecord(BigDecimal amount, String description, String performedBy, LocalDate expenseDate, LocalDateTime createdAt) {
+    public ExpenseRecord(Long id, BigDecimal amount, String description, String performedBy, LocalDate expenseDate, LocalDateTime createdAt) {
+        this.id = id;
         this.amount = amount == null ? BigDecimal.ZERO : amount.setScale(2, RoundingMode.HALF_UP);
         this.description = description == null ? "" : description;
         this.performedBy = performedBy == null ? "" : performedBy;
         this.expenseDate = expenseDate == null ? LocalDate.now() : expenseDate;
         this.createdAt = createdAt == null ? LocalDateTime.now() : createdAt;
+    }
+
+    public Long getId() {
+        return id;
     }
 
     public BigDecimal getAmount() {


### PR DESCRIPTION
## Summary
- add backend support for product sales reporting plus expense and user deletion guardrails
- update the sales panel to show product totals before a selected timestamp
- integrate new product picker and editor dialogs throughout the UI for ordering and maintenance

## Testing
- ⚠️ `mvn -q -DskipTests package` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3886734c832ba1fbafaa0e2f193a