### PR TITLE
Expand dialogs and add fullscreen toggle

### DIFF
--- a/src/main/java/UI/ProductPickerDialog.java
+++ b/src/main/java/UI/ProductPickerDialog.java
@@ -37,9 +37,12 @@ public class ProductPickerDialog extends JDialog {
     private final JToggleButton allButton = new JToggleButton("Tümü");
     private final List<ProductTile> productTiles = new ArrayList<>();
     private final Map<Long, Integer> selectedQuantities = new HashMap<>();
+    private final JButton fullScreenButton = new JButton("Tam ekran");
 
     private Consumer<Selection> onSelect;
     private Long activeCategoryId;
+    private boolean fullScreen;
+    private Rectangle windowedBounds;
 
     public ProductPickerDialog(Window owner, int tableNo) {
         this(owner, tableNo > 0 ? "Masa " + tableNo + " - Ürün Seç" : "Ürün Seç");
@@ -53,7 +56,9 @@ public class ProductPickerDialog extends JDialog {
         super(owner, title, ModalityType.APPLICATION_MODAL);
         setDefaultCloseOperation(DISPOSE_ON_CLOSE);
         setLayout(new BorderLayout(8, 8));
-        setPreferredSize(new Dimension(760, 560));
+        Dimension preferredSize = new Dimension(960, 680);
+        setPreferredSize(preferredSize);
+        setMinimumSize(preferredSize);
 
         add(buildFilterBar(), BorderLayout.NORTH);
         add(buildGridPanel(), BorderLayout.CENTER);
@@ -61,6 +66,7 @@ public class ProductPickerDialog extends JDialog {
 
         loadProducts(null);
         pack();
+        setSize(Math.max(getWidth(), preferredSize.width), Math.max(getHeight(), preferredSize.height));
         setLocationRelativeTo(owner);
     }
 
@@ -69,13 +75,20 @@ public class ProductPickerDialog extends JDialog {
     }
 
     private JComponent buildFilterBar() {
+        JPanel container = new JPanel(new BorderLayout());
         JPanel panel = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 8));
         configureFilterButton(panel, allButton, null);
         populateCategoryButtons(panel);
         allButton.setSelected(true);
         allButton.setPreferredSize(new Dimension(160, 48));
         activeCategoryId = null;
-        return panel;
+        container.add(panel, BorderLayout.CENTER);
+
+        JPanel rightPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 8, 8));
+        configureFullScreenButton();
+        rightPanel.add(fullScreenButton);
+        container.add(rightPanel, BorderLayout.EAST);
+        return container;
     }
 
     private void configureFilterButton(JPanel panel, JToggleButton button, Long categoryId) {
@@ -89,6 +102,10 @@ public class ProductPickerDialog extends JDialog {
         filterGroup.add(button);
         panel.add(button);
         button.setPreferredSize(new Dimension(160, 48));
+    }
+
+    private void configureFullScreenButton() {
+        fullScreenButton.addActionListener(e -> toggleFullScreen());
     }
 
     private void populateCategoryButtons(JPanel panel) {
@@ -140,6 +157,26 @@ public class ProductPickerDialog extends JDialog {
         buttons.add(closeButton);
         panel.add(buttons, BorderLayout.EAST);
         return panel;
+    }
+
+    private void toggleFullScreen() {
+        if (!fullScreen) {
+            windowedBounds = getBounds();
+            Rectangle screenBounds = GraphicsEnvironment.getLocalGraphicsEnvironment().getMaximumWindowBounds();
+            setBounds(screenBounds);
+            fullScreen = true;
+            fullScreenButton.setText("Pencereyi küçült");
+        } else {
+            if (windowedBounds != null) {
+                setBounds(windowedBounds);
+            } else {
+                pack();
+            }
+            fullScreen = false;
+            fullScreenButton.setText("Tam ekran");
+        }
+        revalidate();
+        repaint();
     }
 
     private void loadProducts(Long categoryId) {

--- a/src/main/java/UI/TableOrderDialog.java
+++ b/src/main/java/UI/TableOrderDialog.java
@@ -40,10 +40,13 @@ public class TableOrderDialog extends JDialog {
     private final JLabel statusLabel = new JLabel(" ");
     private final JButton markServedButton = new JButton("Sipariş hazır");
     private final JButton saleButton = new JButton("Satış yap");
+    private final JButton fullScreenButton = new JButton("Tam ekran");
     private final PropertyChangeListener listener = this::handleStateChange;
     private final NumberFormat currencyFormat = NumberFormat.getCurrencyInstance(new Locale("tr", "TR"));
     private final boolean waiterRole;
     private java.util.function.Consumer<Integer> onReadyListener;
+    private boolean fullScreen;
+    private Rectangle windowedBounds;
 
     public TableOrderDialog(Window owner, AppState appState, TableSnapshot snapshot, User user) {
         super(owner, "Masa " + snapshot.getTableNo(), ModalityType.APPLICATION_MODAL);
@@ -54,7 +57,9 @@ public class TableOrderDialog extends JDialog {
 
         setDefaultCloseOperation(DISPOSE_ON_CLOSE);
         setLayout(new BorderLayout(12, 12));
-        setPreferredSize(new Dimension(720, 520));
+        Dimension preferredSize = new Dimension(960, 680);
+        setPreferredSize(preferredSize);
+        setMinimumSize(preferredSize);
 
         add(buildHeader(snapshot), BorderLayout.NORTH);
         add(buildCenter(), BorderLayout.CENTER);
@@ -69,6 +74,7 @@ public class TableOrderDialog extends JDialog {
             }
         });
         pack();
+        setSize(Math.max(getWidth(), preferredSize.width), Math.max(getHeight(), preferredSize.height));
         setLocationRelativeTo(owner);
     }
 
@@ -80,6 +86,8 @@ public class TableOrderDialog extends JDialog {
         JPanel statusPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
         statusLabel.setFont(statusLabel.getFont().deriveFont(Font.BOLD));
         statusPanel.add(statusLabel);
+        configureFullScreenButton();
+        statusPanel.add(fullScreenButton);
         panel.add(statusPanel, BorderLayout.EAST);
         panel.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
         return panel;
@@ -87,6 +95,30 @@ public class TableOrderDialog extends JDialog {
 
     public void setOnReadyListener(java.util.function.Consumer<Integer> l) {
         this.onReadyListener = l;
+    }
+
+    private void configureFullScreenButton() {
+        fullScreenButton.addActionListener(e -> toggleFullScreen());
+    }
+
+    private void toggleFullScreen() {
+        if (!fullScreen) {
+            windowedBounds = getBounds();
+            Rectangle screenBounds = GraphicsEnvironment.getLocalGraphicsEnvironment().getMaximumWindowBounds();
+            setBounds(screenBounds);
+            fullScreen = true;
+            fullScreenButton.setText("Pencereyi küçült");
+        } else {
+            if (windowedBounds != null) {
+                setBounds(windowedBounds);
+            } else {
+                pack();
+            }
+            fullScreen = false;
+            fullScreenButton.setText("Tam ekran");
+        }
+        revalidate();
+        repaint();
     }
     private JComponent buildCenter() {
         JPanel panel = new JPanel(new BorderLayout(12, 12));


### PR DESCRIPTION
## Summary
- enlarge the masa order and product picker dialogs for improved readability
- add a fullscreen toggle button to both dialogs to allow quickly maximizing the workspace

## Testing
- `mvn -q -DskipTests package` *(fails: Maven Central access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d690979ab8832b972b97d8b7687761